### PR TITLE
Update test value to match resultant image.

### DIFF
--- a/doc_source/python-examples.md
+++ b/doc_source/python-examples.md
@@ -167,7 +167,7 @@ plaintext_item = {
     'example': 'data',
     'some numbers': 99,
     'some binary': Binary(b'\x00\x01\x02'),
-    'test': 'testdata'
+    'test': 'test-value'
 }
 ```
 Then, encrypt and sign it\. The encrypt\_python\_item method requires the `CryptoConfig` configuration object\.  


### PR DESCRIPTION
The value for the unencrypted "test" item was "testdata" in the example and "test-value" in the resultant image.  Easier to just change the original test value than to update the image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
