### PR TITLE
Updating the example plaintext_item keys and values

### DIFF
--- a/doc_source/python-examples.md
+++ b/doc_source/python-examples.md
@@ -165,9 +165,9 @@ plaintext_item = {
     'partition_key': 'key1',
     'sort_key': 55,
     'example': 'data',
-    'some numbers': 99,
-    'some binary': Binary(b'\x00\x01\x02'),
-    'test': 'testdata'
+    'numbers': 99,
+    'binary': Binary(b'\x00\x01\x02'),
+    'test': 'test-value'
 }
 ```
 Then, encrypt and sign it\. The encrypt\_python\_item method requires the `CryptoConfig` configuration object\.  


### PR DESCRIPTION
The example plaintext item keys don't match the image in the result.  I've updated *SOME* of them.  I didn't update partition_key, sort_key, or the sort_key value because that would require more changes upstream.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
