### PR TITLE
Fix broken link to AsymmetricStaticProvider

### DIFF
--- a/doc_source/crypto-materials-providers.md
+++ b/doc_source/crypto-materials-providers.md
@@ -24,7 +24,7 @@ For details, see [Most Recent Provider](most-recent-provider.md)\.
 
 **Static Materials Provider**  
 The Static Materials Provider is designed for testing, proof\-of\-concept demonstrations, and legacy compatibility\. It doesn't generate any unique cryptographic materials for each item\. It returns the same encryption and signing keys that you supply, and those keys are used directly to encrypt, decrypt, and sign your table items\.   
-The [Asymmetric Static Provider](https://github.com/aws/aws-dynamodb-encryption-java/blob/master/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/AsymmetricStaticProvider.java) in the Java library is not a static provider\. It just supplies alternate constructors for the [Wrapped CMP](wrapped-provider.md)\. It is safe for production use, but you should use the Wrapped CMP directly whenever possible\.
+The [Asymmetric Static Provider](https://github.com/aws/aws-dynamodb-encryption-java/blob/master/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/AsymmetricStaticProvider.java) in the Java library is not a static provider\. It just supplies alternate constructors for the [Wrapped CMP](wrapped-provider.md)\. It is safe for production use, but you should use the Wrapped CMP directly whenever possible\.
 
 **Topics**
 + [Direct KMS Materials Provider](direct-kms-provider.md)

--- a/doc_source/static-provider.md
+++ b/doc_source/static-provider.md
@@ -7,7 +7,7 @@ To use the Static CMP to encrypt a table item, you supply an [Advanced Encryptio
 Because the Static CMP does not generate any unique cryptographic materials, all table items that you process are encrypted with the same encryption key and signed by the same signing key\. When you use the same key to encrypt the attributes values in numerous items or use the same key or key pair to sign all items, you risk exceeding the cryptographic limits of the keys\. 
 
 **Note**  
-The [Asymmetric Static Provider](https://github.com/aws/aws-dynamodb-encryption-java/blob/master/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/AsymmetricStaticProvider.java) in the Java library is not a static provider\. It just supplies alternate constructors for the [Wrapped CMP](wrapped-provider.md)\. It's safe for production use, but you should use the Wrapped CMP directly whenever possible\.
+The [Asymmetric Static Provider](https://github.com/aws/aws-dynamodb-encryption-java/blob/master/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/AsymmetricStaticProvider.java) in the Java library is not a static provider\. It just supplies alternate constructors for the [Wrapped CMP](wrapped-provider.md)\. It's safe for production use, but you should use the Wrapped CMP directly whenever possible\.
 
 The Static CMP is one of several [cryptographic materials provider](concepts.md#concept-material-provider) \(CMPs\) that the DynamoDB Encryption Client supports\. For information about the other CMPs, see [How to Choose a Cryptographic Materials Provider](crypto-materials-providers.md)\.
 


### PR DESCRIPTION
Any links directly to the source code were broken. For the docs, thats just
AsymmetricStaticProvider. This updates all links in the docs to point to the
correct source code location for AsymmetricStaticProvider.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
